### PR TITLE
Update Node version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 20.x
       - run: npm ci
       - run: npm run lint
       - run: npm test -- --run


### PR DESCRIPTION
## Summary
- allow all Node 20 versions in CI

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6842c2b55d0c83329d9fd03d7b3d8529