### PR TITLE
Add i18n setup and locale files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,9 @@ dist
 
 # Gatsby files
 .cache/
-public
+public/*
+!public/locales/
+!public/locales/**
 
 # Vite build output
 dist/

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,0 +1,15 @@
+{
+  "dashboard": { "title": "Dashboard" },
+  "posts": {
+    "title": "Post Generator",
+    "description": "Create engaging LinkedIn posts with AI assistance."
+  },
+  "history": { "title": "History" },
+  "profile": { "title": "Profile" },
+  "settings": { "title": "Settings" },
+  "auth": {
+    "login": "Log In",
+    "signup": "Sign Up",
+    "signOut": "Sign Out"
+  }
+}

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,0 +1,15 @@
+{
+  "dashboard": { "title": "Panel" },
+  "posts": {
+    "title": "Generador de publicaciones",
+    "description": "Crea publicaciones de LinkedIn con IA."
+  },
+  "history": { "title": "Historial" },
+  "profile": { "title": "Perfil" },
+  "settings": { "title": "Configuración" },
+  "auth": {
+    "login": "Iniciar sesión",
+    "signup": "Registrarse",
+    "signOut": "Cerrar sesión"
+  }
+}

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1,0 +1,15 @@
+{
+  "dashboard": { "title": "Tableau de bord" },
+  "posts": {
+    "title": "Générateur de posts",
+    "description": "Créez des publications LinkedIn avec l'IA."
+  },
+  "history": { "title": "Historique" },
+  "profile": { "title": "Profil" },
+  "settings": { "title": "Paramètres" },
+  "auth": {
+    "login": "Se connecter",
+    "signup": "S'inscrire",
+    "signOut": "Se déconnecter"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import './i18n';
 import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(


### PR DESCRIPTION
## Summary
- add example translations in English, French and Spanish
- load i18n before rendering the app
- allow locale files inside the public folder

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d0b86aa48332ba6f26fd73e46483