### PR TITLE
Improve API error handling

### DIFF
--- a/src/components/messages/MessageGenerator.tsx
+++ b/src/components/messages/MessageGenerator.tsx
@@ -4,7 +4,7 @@ import Card from '../common/Card';
 import Button from '../common/Button';
 import TextArea from '../common/TextArea';
 import Input from '../common/Input';
-import { generateContent, sendLinkedInMessage } from '../../lib/api';
+import { generateContent, sendLinkedInMessage, ApiException } from '../../lib/api';
 
 interface RecipientTarget {
   industry?: string;
@@ -107,7 +107,11 @@ const MessageGenerator: React.FC = () => {
       setGeneratedMessage(text);
     } catch (err) {
       console.error(err);
-      alert('Failed to generate message');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to generate message');
+      }
     } finally {
       setIsGenerating(false);
     }
@@ -133,7 +137,11 @@ const MessageGenerator: React.FC = () => {
       alert(`Message to ${recipientName} sent successfully!`);
     } catch (err) {
       console.error(err);
-      alert('Failed to send message');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to send message');
+      }
     }
   };
 

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -4,7 +4,7 @@ import Card from '../common/Card';
 import Button from '../common/Button';
 import TextArea from '../common/TextArea';
 import Input from '../common/Input';
-import { generateContent, sendLinkedInPost } from '../../lib/api';
+import { generateContent, sendLinkedInPost, ApiException } from '../../lib/api';
 
 
 interface ImagePreview {
@@ -94,7 +94,11 @@ const PostGenerator: React.FC = () => {
       setGeneratedContent(text);
     } catch (err) {
       console.error(err);
-      alert('Failed to generate content');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to generate content');
+      }
     } finally {
       setIsGenerating(false);
     }
@@ -111,7 +115,11 @@ const PostGenerator: React.FC = () => {
       alert('Post published successfully!');
     } catch (err) {
       console.error(err);
-      alert('Failed to publish post');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to publish post');
+      }
     }
   };
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,43 +1,65 @@
+export class ApiException extends Error {
+  status?: number;
+  code?: string;
+
+  constructor(message: string, status?: number, code?: string) {
+    super(message);
+    this.name = 'ApiException';
+    this.status = status;
+    this.code = code;
+  }
+}
+
 export async function generateContent(prompt: string): Promise<string> {
   const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
-  if (!apiKey) throw new Error('OpenAI API key not configured');
-  const response = await fetch('https://api.openai.com/v1/chat/completions', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: prompt }],
-    }),
-  });
-  if (!response.ok) throw new Error('Failed to generate content');
-  const data = await response.json();
-  return data.choices[0].message.content.trim();
+  if (!apiKey) throw new ApiException('OpenAI API key not configured');
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+    if (!response.ok) throw new ApiException('Failed to generate content', response.status);
+    const data = await response.json();
+    return data.choices[0].message.content.trim();
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while generating content');
+  }
 }
 
 export async function sendLinkedInPost(text: string, accessToken: string) {
-  const response = await fetch('https://api.linkedin.com/v2/ugcPosts', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-      'X-Restli-Protocol-Version': '2.0.0',
-    },
-    body: JSON.stringify({
-      author: 'urn:li:person:me',
-      lifecycleState: 'PUBLISHED',
-      specificContent: {
-        'com.linkedin.ugc.ShareContent': {
-          shareCommentary: { text },
-          shareMediaCategory: 'NONE',
-        },
+  try {
+    const response = await fetch('https://api.linkedin.com/v2/ugcPosts', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0',
       },
-      visibility: { visibility: 'PUBLIC' },
-    }),
-  });
-  if (!response.ok) throw new Error('Failed to publish post');
+      body: JSON.stringify({
+        author: 'urn:li:person:me',
+        lifecycleState: 'PUBLISHED',
+        specificContent: {
+          'com.linkedin.ugc.ShareContent': {
+            shareCommentary: { text },
+            shareMediaCategory: 'NONE',
+          },
+        },
+        visibility: { visibility: 'PUBLIC' },
+      }),
+    });
+    if (!response.ok) throw new ApiException('Failed to publish post', response.status);
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while publishing post');
+  }
 }
 
 export async function sendLinkedInMessage(
@@ -45,45 +67,65 @@ export async function sendLinkedInMessage(
   recipientUrn: string,
   accessToken: string,
 ) {
-  const response = await fetch('https://api.linkedin.com/v2/messages', {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-      'Content-Type': 'application/json',
-      'X-Restli-Protocol-Version': '2.0.0',
-    },
-    body: JSON.stringify({
-      recipients: [recipientUrn],
-      subject: 'Automated message',
-      body: text,
-    }),
-  });
-  if (!response.ok) throw new Error('Failed to send message');
+  try {
+    const response = await fetch('https://api.linkedin.com/v2/messages', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+      body: JSON.stringify({
+        recipients: [recipientUrn],
+        subject: 'Automated message',
+        body: text,
+      }),
+    });
+    if (!response.ok) throw new ApiException('Failed to send message', response.status);
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while sending message');
+  }
 }
 
 export async function fetchGoogleCalendarEvents(token: string) {
-  const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error('Failed to fetch Google Calendar events');
-  return (await res.json()).items;
+  try {
+    const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new ApiException('Failed to fetch Google Calendar events', res.status);
+    return (await res.json()).items;
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while fetching Google Calendar events');
+  }
 }
 
 export async function fetchOutlookEvents(token: string) {
-  const res = await fetch('https://graph.microsoft.com/v1.0/me/events', {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error('Failed to fetch Outlook events');
-  return (await res.json()).value;
+  try {
+    const res = await fetch('https://graph.microsoft.com/v1.0/me/events', {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new ApiException('Failed to fetch Outlook events', res.status);
+    return (await res.json()).value;
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while fetching Outlook events');
+  }
 }
 
 export async function fetchLinkedInEvents(token: string) {
-  const res = await fetch('https://api.linkedin.com/v2/events', {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'X-Restli-Protocol-Version': '2.0.0',
-    },
-  });
-  if (!res.ok) throw new Error('Failed to fetch LinkedIn events');
-  return (await res.json()).elements;
+  try {
+    const res = await fetch('https://api.linkedin.com/v2/events', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'X-Restli-Protocol-Version': '2.0.0',
+      },
+    });
+    if (!res.ok) throw new ApiException('Failed to fetch LinkedIn events', res.status);
+    return (await res.json()).elements;
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while fetching LinkedIn events');
+  }
 }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -5,7 +5,7 @@ import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautif
 import Card from '../components/common/Card';
 import Button from '../components/common/Button';
 import Input from '../components/common/Input';
-import { fetchGoogleCalendarEvents, fetchOutlookEvents, fetchLinkedInEvents } from '../lib/api';
+import { fetchGoogleCalendarEvents, fetchOutlookEvents, fetchLinkedInEvents, ApiException } from '../lib/api';
 
 interface Meeting {
   id: string;
@@ -174,7 +174,11 @@ const Calendar: React.FC = () => {
       setMeetings(prev => [...prev, ...events]);
     } catch (err) {
       console.error(err);
-      alert('Failed to fetch Google Calendar events');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to fetch Google Calendar events');
+      }
     }
   };
 
@@ -191,7 +195,11 @@ const Calendar: React.FC = () => {
       setMeetings(prev => [...prev, ...events]);
     } catch (err) {
       console.error(err);
-      alert('Failed to fetch LinkedIn events');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to fetch LinkedIn events');
+      }
     }
   };
 
@@ -214,7 +222,11 @@ const Calendar: React.FC = () => {
       setMeetings(events);
     } catch (err) {
       console.error(err);
-      alert('Failed to sync calendars');
+      if (err instanceof ApiException) {
+        alert(err.message);
+      } else {
+        alert('Failed to sync calendars');
+      }
     } finally {
       setIsSyncing(false);
     }


### PR DESCRIPTION
## Summary
- add `ApiException` class and wrap all fetch calls in `src/lib/api.ts`
- surface detailed API errors in `MessageGenerator`, `PostGenerator` and `Calendar`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842d0c307888332b7b77f829126c006