### PR TITLE
Improve build splitting and lazy loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import MainLayout from './components/layout/MainLayout';
 import Dashboard from './pages/Dashboard';
@@ -7,25 +7,27 @@ import Messages from './pages/Messages';
 import ReceivedMessages from './pages/ReceivedMessages';
 import History from './pages/History';
 import CVGenerator from './pages/CVGenerator';
-import Calendar from './pages/Calendar';
+const Calendar = React.lazy(() => import('./pages/Calendar'));
 import Profile from './pages/Profile';
 import Settings from './pages/Settings';
 
 function App() {
   return (
     <MainLayout>
-      <Routes>
-        <Route path="/" element={<Dashboard />} />
-        <Route path="/posts" element={<Posts />} />
-        <Route path="/messages" element={<Messages />} />
-        <Route path="/received-messages" element={<ReceivedMessages />} />
-        <Route path="/history" element={<History />} />
-        <Route path="/cv-generator" element={<CVGenerator />} />
-        <Route path="/calendar" element={<Calendar />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="*" element={<Navigate to="/" replace />} />
-      </Routes>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Routes>
+          <Route path="/" element={<Dashboard />} />
+          <Route path="/posts" element={<Posts />} />
+          <Route path="/messages" element={<Messages />} />
+          <Route path="/received-messages" element={<ReceivedMessages />} />
+          <Route path="/history" element={<History />} />
+          <Route path="/cv-generator" element={<CVGenerator />} />
+          <Route path="/calendar" element={<Calendar />} />
+          <Route path="/profile" element={<Profile />} />
+          <Route path="/settings" element={<Settings />} />
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </Suspense>
     </MainLayout>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,17 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: [
+            'react',
+            'react-dom',
+            'react-router-dom',
+          ],
+        },
+      },
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- lazy load the Calendar page and wrap routes with `Suspense`
- split vendor code via `manualChunks` in Vite

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6842d0c4c64c8332bfdf2318706d9451