### PR TITLE
Add generator component tests

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInPost: vi.fn(),
+  sendLinkedInMessage: vi.fn(),
+}));
+
+import { generateContent } from '../lib/api';
+import MessageGenerator from '../components/messages/MessageGenerator';
+
+const generateContentMock = generateContent as any;
+
+describe('MessageGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates a message on success', async () => {
+    generateContentMock.mockResolvedValue('Hello there');
+    render(<MessageGenerator />);
+
+    fireEvent.change(screen.getAllByPlaceholderText(/enter recipient's name/i)[0], { target: { value: 'John' } });
+    fireEvent.change(screen.getAllByPlaceholderText(/describe what you want/i)[0], { target: { value: 'Say hi' } });
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /generate message/i })[0]
+      );
+    });
+
+    expect(generateContentMock).toHaveBeenCalled();
+    expect(await screen.findByDisplayValue('Hello there')).toBeInTheDocument();
+  });
+
+  it('alerts when generation fails', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    generateContentMock.mockRejectedValue(new Error('bad'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<MessageGenerator />);
+
+    fireEvent.change(screen.getAllByPlaceholderText(/enter recipient's name/i)[0], { target: { value: 'John' } });
+    fireEvent.change(screen.getAllByPlaceholderText(/describe what you want/i)[0], { target: { value: 'Say hi' } });
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /generate message/i })[0]
+      );
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Failed to generate message');
+    });
+    alertSpy.mockRestore();
+  });
+});

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInPost: vi.fn(),
+  sendLinkedInMessage: vi.fn(),
+}));
+
+import { generateContent } from '../lib/api';
+import PostGenerator from '../components/posts/PostGenerator';
+
+const generateContentMock = generateContent as any;
+
+describe('PostGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates post content on success', async () => {
+    generateContentMock.mockResolvedValue('Generated text');
+    render(<PostGenerator />);
+
+    fireEvent.change(
+      screen.getAllByPlaceholderText(/enter a topic/i)[0],
+      { target: { value: 'topic' } }
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /generate content/i })[0]
+      );
+    });
+
+    expect(generateContentMock).toHaveBeenCalledWith('topic');
+    expect(await screen.findByDisplayValue('Generated text')).toBeInTheDocument();
+  });
+
+  it('shows an alert when generation fails', async () => {
+    const alertSpy = vi.spyOn(window, 'alert').mockImplementation(() => {});
+    generateContentMock.mockRejectedValue(new Error('fail'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<PostGenerator />);
+
+    fireEvent.change(
+      screen.getAllByPlaceholderText(/enter a topic/i)[0],
+      { target: { value: 'topic' } }
+    );
+    await act(async () => {
+      fireEvent.click(
+        screen.getAllByRole('button', { name: /generate content/i })[0]
+      );
+    });
+
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith('Failed to generate content');
+    });
+    alertSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PostGenerator and MessageGenerator components
- mock the API layer to avoid network calls
- verify successful generation and error handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842d0baf9608332856f3eb1cc35d07d