### PR TITLE
Add generator component tests

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageGenerator from '../components/messages/MessageGenerator';
+import type { Mock } from 'vitest';
+import * as api from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInPost: vi.fn(),
+  sendLinkedInMessage: vi.fn(),
+  ApiException: class ApiException extends Error {},
+}));
+
+const generateContent = api.generateContent as unknown as Mock;
+
+describe('MessageGenerator', () => {
+  it('applies template and generates message', async () => {
+    (generateContent as any).mockResolvedValue('hello message');
+    render(<MessageGenerator />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Enter recipient's name/i), {
+      target: { value: 'John Doe' },
+    });
+
+    const template = screen.getByText(/Mutual Interest/i);
+    fireEvent.click(template);
+
+    const expectedTemplate =
+      'I noticed we both share an interest in [topic]. Would love to connect and possibly exchange ideas about [industry/topic].';
+    const prompt = screen.getByPlaceholderText(/Describe what you want to say/i);
+    expect(prompt).toHaveValue(expectedTemplate);
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate Message/i }));
+
+    expect(generateContent).toHaveBeenCalledWith(expectedTemplate);
+    expect(await screen.findByDisplayValue('hello message')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PostGenerator from '../components/posts/PostGenerator';
+import type { Mock } from 'vitest';
+import * as api from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInPost: vi.fn(),
+  sendLinkedInMessage: vi.fn(),
+  ApiException: class ApiException extends Error {},
+}));
+
+const generateContent = api.generateContent as unknown as Mock;
+
+describe('PostGenerator', () => {
+  it('calls generateContent and displays returned text', async () => {
+    (generateContent as any).mockResolvedValue('mock post');
+    render(<PostGenerator />);
+    const input = screen.getByPlaceholderText(/Enter a topic/i);
+    fireEvent.change(input, { target: { value: 'test prompt' } });
+    const button = screen.getByRole('button', { name: /Generate Content/i });
+    fireEvent.click(button);
+    expect(generateContent).toHaveBeenCalledWith('test prompt');
+    expect(await screen.findByDisplayValue('mock post')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PostGenerator to verify content generation
- add tests for MessageGenerator to check template application and message creation

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6842ddb8ef0883328e329b099b905c46