### PR TITLE
Add vitest unit tests for API and auth store

### DIFF
--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  generateContent,
+  sendLinkedInPost,
+  sendLinkedInMessage,
+  fetchGoogleCalendarEvents,
+  fetchOutlookEvents,
+  fetchLinkedInEvents,
+  ApiException,
+} from '../lib/api';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  // @ts-ignore
+  global.fetch = fetchMock;
+  vi.resetModules();
+  process.env.VITE_OPENAI_API_KEY = 'key';
+});
+
+describe('generateContent', () => {
+  it('posts prompt to OpenAI and returns content', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'hello' } }] }),
+    });
+
+    const text = await generateContent('prompt');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(text).toBe('hello');
+  });
+
+  it('throws ApiException when request fails', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    await expect(generateContent('prompt')).rejects.toBeInstanceOf(ApiException);
+  });
+});
+
+describe('sendLinkedInPost', () => {
+  it('calls LinkedIn post endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await sendLinkedInPost('text', 'token');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.linkedin.com/v2/ugcPosts',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('throws ApiException on failure', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 400 });
+    await expect(sendLinkedInPost('text', 'token')).rejects.toBeInstanceOf(ApiException);
+  });
+});
+
+describe('sendLinkedInMessage', () => {
+  it('calls LinkedIn message endpoint', async () => {
+    fetchMock.mockResolvedValue({ ok: true });
+    await sendLinkedInMessage('hi', 'urn', 'token');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.linkedin.com/v2/messages',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});
+
+describe('calendar fetch helpers', () => {
+  it('fetches Google events', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ items: [1] }) });
+    const data = await fetchGoogleCalendarEvents('t');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://www.googleapis.com/calendar/v3/calendars/primary/events',
+      expect.any(Object),
+    );
+    expect(data).toEqual([1]);
+  });
+
+  it('fetches Outlook events', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ value: [2] }) });
+    const data = await fetchOutlookEvents('t');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://graph.microsoft.com/v1.0/me/events',
+      expect.any(Object),
+    );
+    expect(data).toEqual([2]);
+  });
+
+  it('fetches LinkedIn events', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ elements: [3] }) });
+    const data = await fetchLinkedInEvents('t');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.linkedin.com/v2/events',
+      expect.any(Object),
+    );
+    expect(data).toEqual([3]);
+  });
+});

--- a/src/__tests__/authStore.test.ts
+++ b/src/__tests__/authStore.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { User } from '@supabase/supabase-js';
+
+const authMock = {
+  signOut: vi.fn().mockResolvedValue(undefined),
+  getSession: vi.fn().mockResolvedValue({ data: { session: null } }),
+  onAuthStateChange: vi.fn(),
+};
+
+let useAuthStore: any;
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.doMock('../lib/supabase', () => ({ supabase: { auth: authMock } }));
+  const mod = await import('../stores/authStore');
+  useAuthStore = mod.useAuthStore;
+  authMock.signOut.mockClear();
+  useAuthStore.setState({ user: { id: '1' } as unknown as User, loading: false });
+});
+
+describe('authStore signOut', () => {
+  it('clears the user state', async () => {
+    await useAuthStore.getState().signOut();
+    expect(authMock.signOut).toHaveBeenCalled();
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add API tests covering fetch helpers
- add auth store tests mocking supabase

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842ddb7b01083328428f82289682f41