### PR TITLE
Update API mocks in generator tests

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import MessageGenerator from '../components/messages/MessageGenerator';
+import { generateContent } from '../lib/api';
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    generateContent: vi.fn(),
+    sendLinkedInPost: vi.fn(),
+    sendLinkedInMessage: vi.fn(),
+  };
+});
+
+describe('MessageGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (generateContent as unknown as vi.Mock).mockResolvedValue('Generated');
+    const env = import.meta.env as Record<string, string>;
+    env.VITE_LINKEDIN_API_KEY = 'token';
+  });
+
+  it('calls generateContent when generate button is clicked', async () => {
+    render(<MessageGenerator />);
+    fireEvent.change(screen.getByPlaceholderText("Enter recipient's name"), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        /Describe what you want to say to this person or choose a template from the right.../i,
+      ),
+      { target: { value: 'Hello' } },
+    );
+    fireEvent.click(screen.getByText(/generate message/i));
+    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+  });
+});

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import PostGenerator from '../components/posts/PostGenerator';
+import { generateContent } from '../lib/api';
+
+vi.mock('../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
+  return {
+    ...actual,
+    generateContent: vi.fn(),
+    sendLinkedInPost: vi.fn(),
+    sendLinkedInMessage: vi.fn(),
+  };
+});
+
+describe('PostGenerator', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (generateContent as unknown as vi.Mock).mockResolvedValue('Generated');
+    const env = import.meta.env as Record<string, string>;
+    env.VITE_LINKEDIN_API_KEY = 'token';
+  });
+
+  it('calls generateContent when generate button is clicked', async () => {
+    render(<PostGenerator />);
+    fireEvent.change(
+      screen.getByPlaceholderText(/Enter a topic or detailed instructions for GPT.../i),
+      { target: { value: 'Topic' } },
+    );
+    fireEvent.click(screen.getByText(/generate content/i));
+    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for PostGenerator and MessageGenerator
- mock lib/api with asynchronous import to spy on methods

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6842eb4eea6c8332b037ff4b882ca680