### PR TITLE
Add missing generator tests

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, Mock, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MessageGenerator from '../components/messages/MessageGenerator';
+import { generateContent } from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInMessage: vi.fn(),
+  ApiException: class ApiException extends Error {},
+}));
+
+const generateContentMock = generateContent as Mock<
+  Parameters<typeof generateContent>,
+  ReturnType<typeof generateContent>
+>;
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('MessageGenerator', () => {
+  it('calls generateContent when generating a message', async () => {
+    generateContentMock.mockResolvedValueOnce('hello');
+    render(<MessageGenerator />);
+
+    const nameInput = screen.getByPlaceholderText(/enter recipient's name/i);
+    fireEvent.change(nameInput, { target: { value: 'John' } });
+
+    const textarea = screen.getByPlaceholderText(/describe what you want to say/i);
+    fireEvent.change(textarea, { target: { value: 'Hi' } });
+
+    const button = screen.getByRole('button', { name: /generate message/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(generateContentMock).toHaveBeenCalledWith('Hi');
+    });
+  });
+});

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, Mock, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import PostGenerator from '../components/posts/PostGenerator';
+import { generateContent } from '../lib/api';
+
+vi.mock('../lib/api', () => ({
+  generateContent: vi.fn(),
+  sendLinkedInPost: vi.fn(),
+  ApiException: class ApiException extends Error {},
+}));
+
+const generateContentMock = generateContent as Mock<
+  Parameters<typeof generateContent>,
+  ReturnType<typeof generateContent>
+>;
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('PostGenerator', () => {
+  it('calls generateContent when generating a post', async () => {
+    generateContentMock.mockResolvedValueOnce('post');
+    render(<PostGenerator />);
+
+    const textarea = screen.getByPlaceholderText(/enter a topic/i);
+    fireEvent.change(textarea, { target: { value: 'Topic' } });
+
+    const button = screen.getByRole('button', { name: /generate content/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(generateContentMock).toHaveBeenCalledWith('Topic');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for MessageGenerator and PostGenerator
- type `generateContentMock` with `Mock<Parameters, ReturnType>`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842eb58938483329e09779cea85236b