### PR TITLE
Add tests for posting and sending LinkedIn content

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import MessageGenerator from '../components/messages/MessageGenerator';
-import { generateContent } from '../lib/api';
+import { generateContent, sendLinkedInMessage } from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
@@ -21,6 +21,10 @@ describe('MessageGenerator', () => {
     env.VITE_LINKEDIN_API_KEY = 'token';
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('calls generateContent when generate button is clicked', async () => {
     render(<MessageGenerator />);
     fireEvent.change(screen.getByPlaceholderText("Enter recipient's name"), {
@@ -34,5 +38,23 @@ describe('MessageGenerator', () => {
     );
     fireEvent.click(screen.getByText(/generate message/i));
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
+  });
+
+  it('sends generated message when send button is clicked', async () => {
+    render(<MessageGenerator />);
+    fireEvent.change(screen.getByPlaceholderText("Enter recipient's name"), {
+      target: { value: 'John Doe' },
+    });
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        /Describe what you want to say to this person or choose a template from the right.../i,
+      ),
+      { target: { value: 'Hello' } },
+    );
+    fireEvent.click(screen.getByText(/generate message/i));
+    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText(/send message/i));
+    await waitFor(() => expect(sendLinkedInMessage).toHaveBeenCalledWith('Generated', 'urn:li:person:john123', 'token'));
   });
 });

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import PostGenerator from '../components/posts/PostGenerator';
-import { generateContent } from '../lib/api';
+import { generateContent, sendLinkedInPost } from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
@@ -21,6 +21,10 @@ describe('PostGenerator', () => {
     env.VITE_LINKEDIN_API_KEY = 'token';
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it('calls generateContent when generate button is clicked', async () => {
     render(<PostGenerator />);
     fireEvent.change(
@@ -29,5 +33,18 @@ describe('PostGenerator', () => {
     );
     fireEvent.click(screen.getByText(/generate content/i));
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
+  });
+
+  it('publishes generated content when publish button is clicked', async () => {
+    render(<PostGenerator />);
+    fireEvent.change(
+      screen.getByPlaceholderText(/Enter a topic or detailed instructions for GPT.../i),
+      { target: { value: 'Topic' } },
+    );
+    fireEvent.click(screen.getByText(/generate content/i));
+    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText(/publish now/i));
+    await waitFor(() => expect(sendLinkedInPost).toHaveBeenCalledWith('Generated', 'token'));
   });
 });


### PR DESCRIPTION
## Summary
- expand `PostGenerator` tests to cover publishing posts
- expand `MessageGenerator` tests to cover sending messages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f12da8b48332b10ee062f51f1f58