### PR TITLE
Add API rejection tests

### DIFF
--- a/src/__tests__/api.errorPropagation.test.ts
+++ b/src/__tests__/api.errorPropagation.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ApiException, generateContent, sendLinkedInPost, sendLinkedInMessage } from '../lib/api';
+
+describe('API error propagation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('generateContent rejects ApiException with status 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }));
+    const env = import.meta.env as Record<string, string>;
+    env.VITE_OPENAI_API_KEY = 'token';
+
+    const promise = generateContent('prompt');
+    await expect(promise).rejects.toBeInstanceOf(ApiException);
+    await expect(promise).rejects.toHaveProperty('status', 500);
+  });
+
+  it('sendLinkedInPost rejects ApiException with status 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }));
+
+    const promise = sendLinkedInPost('text', 'token');
+    await expect(promise).rejects.toBeInstanceOf(ApiException);
+    await expect(promise).rejects.toHaveProperty('status', 500);
+  });
+
+  it('sendLinkedInMessage rejects ApiException with status 500', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({}) }));
+
+    const promise = sendLinkedInMessage('text', 'urn:li:person:test', 'token');
+    await expect(promise).rejects.toBeInstanceOf(ApiException);
+    await expect(promise).rejects.toHaveProperty('status', 500);
+  });
+});


### PR DESCRIPTION
## Summary
- verify that API functions reject with ApiException when fetch fails
- mock fetch to simulate HTTP 500 for generateContent, sendLinkedInPost and sendLinkedInMessage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6842f47d74ac8332b308cc19ab84068c