### PR TITLE
feat: add platform selection for posts

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -8,7 +8,7 @@ vi.mock('../lib/api', async () => {
   return {
     ...actual,
     generateContent: vi.fn(),
-    sendLinkedInPost: vi.fn(),
+    publishPost: vi.fn(),
     sendLinkedInMessage: vi.fn(),
   };
 });

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import PostGenerator from '../components/posts/PostGenerator';
-import { generateContent, sendLinkedInPost } from '../lib/api';
+import { generateContent, publishPost } from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
   return {
     ...actual,
     generateContent: vi.fn(),
-    sendLinkedInPost: vi.fn(),
+    publishPost: vi.fn(),
     sendLinkedInMessage: vi.fn(),
   };
 });
@@ -45,6 +45,6 @@ describe('PostGenerator', () => {
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
 
     fireEvent.click(screen.getByText(/publish now/i));
-    await waitFor(() => expect(sendLinkedInPost).toHaveBeenCalledWith('Generated', 'token'));
+    await waitFor(() => expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'));
   });
 });

--- a/src/components/messages/MessageGenerator.tsx
+++ b/src/components/messages/MessageGenerator.tsx
@@ -110,7 +110,7 @@ const MessageGenerator: React.FC = () => {
         ? `As a professional in the ${targeting.industry} industry with ${targeting.experience} of experience, `
         : '';
       const promptText = `${targetingContext}${prompt}`;
-      const text = await generateContent(promptText);
+      const text = await generateContent(promptText, 'LinkedIn');
       setGeneratedMessage(text);
     } catch (err) {
       console.error(err);

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -8,7 +8,7 @@ import Card from '../common/Card';
 import Button from '../common/Button';
 import TextArea from '../common/TextArea';
 import Input from '../common/Input';
-import { generateContent, sendLinkedInPost, ApiException } from '../../lib/api';
+import { generateContent, publishPost, ApiException } from '../../lib/api';
 
 
 interface ImagePreview {
@@ -33,6 +33,7 @@ const PostGenerator: React.FC = () => {
   const [imageUrl, setImageUrl] = useState('');
   const [selectedImages, setSelectedImages] = useState<ImagePreview[]>([]);
   const [dragActive, setDragActive] = useState(false);
+  const [platform, setPlatform] = useState('LinkedIn');
   
 
   const handleImageUpload = (files: FileList | null) => {
@@ -97,7 +98,7 @@ const PostGenerator: React.FC = () => {
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const text = await generateContent(prompt);
+      const text = await generateContent(prompt, platform);
       setGeneratedContent(text);
     } catch (err) {
       console.error(err);
@@ -112,13 +113,14 @@ const PostGenerator: React.FC = () => {
   };
 
   const handlePublish = async () => {
-    const token = import.meta.env.VITE_LINKEDIN_API_KEY;
+    const env = import.meta.env as Record<string, string | undefined>;
+    const token = env[`VITE_${platform.toUpperCase()}_API_KEY`];
     if (!token) {
-      alert('LinkedIn API key not configured');
+      alert(`${platform} API key not configured`);
       return;
     }
     try {
-      await sendLinkedInPost(generatedContent, token);
+      await publishPost(generatedContent, platform, token);
       alert('Post published successfully!');
     } catch (err) {
       console.error(err);
@@ -131,9 +133,23 @@ const PostGenerator: React.FC = () => {
   };
 
   return (
-    <Card title="Create LinkedIn Post">
+    <Card title="Create Social Media Post">
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="md:col-span-2">
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Platform
+            </label>
+            <select
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#0A66C2] focus:ring-[#0A66C2]"
+            >
+              <option value="LinkedIn">LinkedIn</option>
+              <option value="Twitter">Twitter</option>
+              <option value="Facebook">Facebook</option>
+            </select>
+          </div>
           <div className="mb-4">
             <TextArea
               label="What would you like to post about?"


### PR DESCRIPTION
## Summary
- add platform dropdown and state to PostGenerator
- expand API for platform-specific generation and publishing
- adjust tests for new publish workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a63f637083328bb7d295c60ce900