### PR TITLE
feat: add variation selection for posts

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../lib/api', async () => {
 describe('MessageGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (generateContent as unknown as vi.Mock).mockResolvedValue('Generated');
+    (generateContent as unknown as vi.Mock).mockResolvedValue(['Generated']);
     const env = import.meta.env as Record<string, string>;
     env.VITE_LINKEDIN_API_KEY = 'token';
   });

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../lib/api', async () => {
 describe('PostGenerator', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    (generateContent as unknown as vi.Mock).mockResolvedValue('Generated');
+    (generateContent as unknown as vi.Mock).mockResolvedValue(['Generated']);
     const env = import.meta.env as Record<string, string>;
     env.VITE_LINKEDIN_API_KEY = 'token';
   });

--- a/src/components/messages/MessageGenerator.tsx
+++ b/src/components/messages/MessageGenerator.tsx
@@ -110,7 +110,7 @@ const MessageGenerator: React.FC = () => {
         ? `As a professional in the ${targeting.industry} industry with ${targeting.experience} of experience, `
         : '';
       const promptText = `${targetingContext}${prompt}`;
-      const text = await generateContent(promptText);
+      const [text] = await generateContent(promptText);
       setGeneratedMessage(text);
     } catch (err) {
       console.error(err);

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -24,6 +24,8 @@ interface ImagePreview {
 const PostGenerator: React.FC = () => {
   const [prompt, setPrompt] = useState('');
   const [generatedContent, setGeneratedContent] = useState('');
+  const [variations, setVariations] = useState<string[]>([]);
+  const [variationCount, setVariationCount] = useState(1);
   const [isGenerating, setIsGenerating] = useState(false);
   const [showScheduler, setShowScheduler] = useState(false);
   const [showTargeting, setShowTargeting] = useState(false);
@@ -97,8 +99,9 @@ const PostGenerator: React.FC = () => {
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const text = await generateContent(prompt);
-      setGeneratedContent(text);
+      const texts = await generateContent(prompt, variationCount);
+      setVariations(texts);
+      setGeneratedContent(texts[0] || '');
     } catch (err) {
       console.error(err);
       if (err instanceof ApiException) {
@@ -143,7 +146,17 @@ const PostGenerator: React.FC = () => {
               onChange={(e) => setPrompt(e.target.value)}
             />
           </div>
-          
+
+          <div className="mb-4">
+            <Input
+              type="number"
+              label="Number of Variations"
+              min={1}
+              value={variationCount}
+              onChange={(e) => setVariationCount(Math.max(1, Number(e.target.value)))}
+            />
+          </div>
+
           <div className="mb-6 flex flex-wrap gap-4">
             <Button
               onClick={handleGenerate}
@@ -161,6 +174,22 @@ const PostGenerator: React.FC = () => {
               {showTargeting ? 'Hide Targeting' : 'Show Targeting'}
             </Button>
           </div>
+
+          {variations.length > 1 && (
+            <div className="mb-6">
+              <h4 className="text-sm font-medium text-gray-700 mb-2">Variations</h4>
+              <div className="space-y-4">
+                {variations.map((text, index) => (
+                  <div key={index} className="p-4 border rounded-md">
+                    <p className="text-sm whitespace-pre-wrap mb-2">{text}</p>
+                    <Button size="sm" onClick={() => setGeneratedContent(text)}>
+                      Select
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
 
           {generatedContent && (
             <div className="mb-6">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,10 +14,11 @@ export class ApiException extends Error {
  * Generates text using the OpenAI Chat Completion API.
  *
  * @param prompt - Text prompt describing the desired content.
- * @returns The generated text from the model.
+ * @param n - Number of variations to generate. Defaults to 1.
+ * @returns An array of generated texts from the model.
  * @throws ApiException When the API key is missing or the request fails.
  */
-export async function generateContent(prompt: string): Promise<string> {
+export async function generateContent(prompt: string, n = 1): Promise<string[]> {
   const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
   if (!apiKey) throw new ApiException('OpenAI API key not configured');
   try {
@@ -30,11 +31,12 @@ export async function generateContent(prompt: string): Promise<string> {
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
         messages: [{ role: 'user', content: prompt }],
+        n,
       }),
     });
     if (!response.ok) throw new ApiException('Failed to generate content', response.status);
     const data = await response.json();
-    return data.choices[0].message.content.trim();
+    return data.choices.map((choice: any) => choice.message.content.trim());
   } catch (err) {
     if (err instanceof ApiException) throw err;
     throw new ApiException('Network error while generating content');


### PR DESCRIPTION
## Summary
- allow selecting number of post variations and show each with a Select option
- support OpenAI `n` parameter to fetch multiple completions
- adjust message generator and tests for new API response format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890a64271848332a5d37b7ce448f33b