### PR TITLE
feat: add tone and hashtag support

### DIFF
--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -23,6 +23,8 @@ interface ImagePreview {
  */
 const PostGenerator: React.FC = () => {
   const [prompt, setPrompt] = useState('');
+  const [tone, setTone] = useState('');
+  const [hashtags, setHashtags] = useState('');
   const [generatedContent, setGeneratedContent] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
   const [showScheduler, setShowScheduler] = useState(false);
@@ -97,7 +99,7 @@ const PostGenerator: React.FC = () => {
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const text = await generateContent(prompt);
+      const text = await generateContent(prompt, tone, hashtags);
       setGeneratedContent(text);
     } catch (err) {
       console.error(err);
@@ -118,7 +120,10 @@ const PostGenerator: React.FC = () => {
       return;
     }
     try {
-      await sendLinkedInPost(generatedContent, token);
+      const finalText = hashtags
+        ? `${generatedContent}\n\n${hashtags}`
+        : generatedContent;
+      await sendLinkedInPost(finalText, token);
       alert('Post published successfully!');
     } catch (err) {
       console.error(err);
@@ -143,7 +148,25 @@ const PostGenerator: React.FC = () => {
               onChange={(e) => setPrompt(e.target.value)}
             />
           </div>
-          
+
+          <div className="mb-4">
+            <Input
+              label="Tone/Voice"
+              placeholder="e.g., professional, friendly"
+              value={tone}
+              onChange={(e) => setTone(e.target.value)}
+            />
+          </div>
+
+          <div className="mb-4">
+            <Input
+              label="Hashtags"
+              placeholder="#ai, #career"
+              value={hashtags}
+              onChange={(e) => setHashtags(e.target.value)}
+            />
+          </div>
+
           <div className="mb-6 flex flex-wrap gap-4">
             <Button
               onClick={handleGenerate}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -14,13 +14,23 @@ export class ApiException extends Error {
  * Generates text using the OpenAI Chat Completion API.
  *
  * @param prompt - Text prompt describing the desired content.
+ * @param tone - Desired tone or voice for the generated text.
+ * @param hashtags - Optional hashtags to incorporate into the content.
  * @returns The generated text from the model.
  * @throws ApiException When the API key is missing or the request fails.
  */
-export async function generateContent(prompt: string): Promise<string> {
+export async function generateContent(
+  prompt: string,
+  tone?: string,
+  hashtags?: string,
+): Promise<string> {
   const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
   if (!apiKey) throw new ApiException('OpenAI API key not configured');
   try {
+    const parts = [prompt];
+    if (tone) parts.push(`Tone/Voice: ${tone}`);
+    if (hashtags) parts.push(`Include these hashtags: ${hashtags}`);
+    const fullPrompt = parts.join('\n');
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
       headers: {
@@ -29,7 +39,7 @@ export async function generateContent(prompt: string): Promise<string> {
       },
       body: JSON.stringify({
         model: 'gpt-3.5-turbo',
-        messages: [{ role: 'user', content: prompt }],
+        messages: [{ role: 'user', content: fullPrompt }],
       }),
     });
     if (!response.ok) throw new ApiException('Failed to generate content', response.status);


### PR DESCRIPTION
## Summary
- allow specifying tone/voice and hashtags when composing posts
- include tone and hashtags in the generation prompt
- append hashtags to posts before publishing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a6497d1083328c79a5c32ed71648