### PR TITLE
Append hashtags to generated posts

### DIFF
--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -43,8 +43,17 @@ describe('PostGenerator', () => {
     );
     fireEvent.click(screen.getByText(/generate content/i));
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText(/hashtags/i), {
+      target: { value: '#one #two' },
+    });
 
     fireEvent.click(screen.getByText(/publish now/i));
-    await waitFor(() => expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'));
+    await waitFor(() =>
+      expect(publishPost).toHaveBeenCalledWith(
+        'Generated #one #two',
+        'LinkedIn',
+        'token',
+      ),
+    );
   });
 });

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -34,6 +34,7 @@ const PostGenerator: React.FC = () => {
   const [selectedImages, setSelectedImages] = useState<ImagePreview[]>([]);
   const [dragActive, setDragActive] = useState(false);
   const [platform, setPlatform] = useState('LinkedIn');
+  const [hashtags, setHashtags] = useState('');
   
 
   const handleImageUpload = (files: FileList | null) => {
@@ -119,8 +120,15 @@ const PostGenerator: React.FC = () => {
       alert(`${platform} API key not configured`);
       return;
     }
+    const trimmedHashtags = hashtags.trim();
+    const baseContent = generatedContent.trim();
+    const finalContent =
+      trimmedHashtags && !baseContent.endsWith(trimmedHashtags)
+        ? `${baseContent} ${trimmedHashtags}`
+        : baseContent;
+    setGeneratedContent(finalContent);
     try {
-      await publishPost(generatedContent, platform, token);
+      await publishPost(finalContent, platform, token);
       alert('Post published successfully!');
     } catch (err) {
       console.error(err);
@@ -201,6 +209,15 @@ const PostGenerator: React.FC = () => {
                     <Sparkles className="h-4 w-4 text-[#0A66C2]" />
                   </Button>
                 </div>
+              </div>
+              <div className="mt-4">
+                <Input
+                  label="Hashtags"
+                  placeholder="#example #tags"
+                  value={hashtags}
+                  onChange={(e) => setHashtags(e.target.value)}
+                  name="hashtags"
+                />
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- allow authors to supply hashtags via a dedicated input
- append provided hashtags to post content before publishing
- test that publishPost receives content with hashtags appended

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890b25d1d608332a602780b33ab1418