### PR TITLE
feat: add tone and hashtags to content generation

### DIFF
--- a/src/__tests__/MessageGenerator.test.tsx
+++ b/src/__tests__/MessageGenerator.test.tsx
@@ -37,7 +37,9 @@ describe('MessageGenerator', () => {
       { target: { value: 'Hello' } },
     );
     fireEvent.click(screen.getByText(/generate message/i));
-    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(generateContent).toHaveBeenCalledWith('Hello', 'LinkedIn', 'neutral', []),
+    );
   });
 
   it('sends generated message when send button is clicked', async () => {
@@ -52,7 +54,9 @@ describe('MessageGenerator', () => {
       { target: { value: 'Hello' } },
     );
     fireEvent.click(screen.getByText(/generate message/i));
-    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(generateContent).toHaveBeenCalledWith('Hello', 'LinkedIn', 'neutral', []),
+    );
 
     fireEvent.click(screen.getByText(/send message/i));
     await waitFor(() => expect(sendLinkedInMessage).toHaveBeenCalledWith('Generated', 'urn:li:person:john123', 'token'));

--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -32,7 +32,9 @@ describe('PostGenerator', () => {
       { target: { value: 'Topic' } },
     );
     fireEvent.click(screen.getByText(/generate content/i));
-    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(generateContent).toHaveBeenCalledWith('Topic', 'LinkedIn', 'neutral', []),
+    );
   });
 
   it('publishes generated content when publish button is clicked', async () => {
@@ -42,7 +44,9 @@ describe('PostGenerator', () => {
       { target: { value: 'Topic' } },
     );
     fireEvent.click(screen.getByText(/generate content/i));
-    await waitFor(() => expect(generateContent).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(generateContent).toHaveBeenCalledWith('Topic', 'LinkedIn', 'neutral', []),
+    );
 
     fireEvent.click(screen.getByText(/publish now/i));
     await waitFor(() => expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'));

--- a/src/components/messages/MessageGenerator.tsx
+++ b/src/components/messages/MessageGenerator.tsx
@@ -110,7 +110,7 @@ const MessageGenerator: React.FC = () => {
         ? `As a professional in the ${targeting.industry} industry with ${targeting.experience} of experience, `
         : '';
       const promptText = `${targetingContext}${prompt}`;
-      const text = await generateContent(promptText, 'LinkedIn');
+      const text = await generateContent(promptText, 'LinkedIn', 'neutral', []);
       setGeneratedMessage(text);
     } catch (err) {
       console.error(err);

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -98,7 +98,7 @@ const PostGenerator: React.FC = () => {
   const handleGenerate = async () => {
     setIsGenerating(true);
     try {
-      const text = await generateContent(prompt, platform);
+      const text = await generateContent(prompt, platform, 'neutral', []);
       setGeneratedContent(text);
     } catch (err) {
       console.error(err);

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,10 +15,17 @@ export class ApiException extends Error {
  *
  * @param prompt - Text prompt describing the desired content.
  * @param platform - Target platform for the content which influences tone and style.
+ * @param tone - Desired tone for the generated content.
+ * @param hashtags - Optional list of hashtags to influence the generation.
  * @returns The generated text from the model.
  * @throws ApiException When the API key is missing or the request fails.
  */
-export async function generateContent(prompt: string, platform: string): Promise<string> {
+export async function generateContent(
+  prompt: string,
+  platform: string,
+  tone: string,
+  hashtags?: string[],
+): Promise<string> {
   const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
   if (!apiKey) throw new ApiException('OpenAI API key not configured');
 
@@ -41,7 +48,10 @@ export async function generateContent(prompt: string, platform: string): Promise
         model: 'gpt-3.5-turbo',
         messages: [
           { role: 'system', content: systemPrompt },
-          { role: 'user', content: prompt },
+          {
+            role: 'user',
+            content: `${prompt}\nTone: ${tone}\nHashtags: ${hashtags?.join(' ')}`,
+          },
         ],
       }),
     });


### PR DESCRIPTION
## Summary
- allow `generateContent` to accept tone and optional hashtags and include them in the prompt
- pass tone and hashtags from post and message generators
- update tests for new arguments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6890b25c3e988332afeca45fd55ae45a