### PR TITLE
Allow publishing to multiple platforms

### DIFF
--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import PostGenerator from '../components/posts/PostGenerator';
-import { generateContent, publishPost } from '../lib/api';
+import { generateContent, publishPosts } from '../lib/api';
 
 vi.mock('../lib/api', async () => {
   const actual = await vi.importActual<typeof import('../lib/api')>('../lib/api');
   return {
     ...actual,
     generateContent: vi.fn(),
-    publishPost: vi.fn(),
+    publishPosts: vi.fn(),
     sendLinkedInMessage: vi.fn(),
   };
 });
@@ -19,6 +19,7 @@ describe('PostGenerator', () => {
     (generateContent as unknown as vi.Mock).mockResolvedValue('Generated');
     const env = import.meta.env as Record<string, string>;
     env.VITE_LINKEDIN_API_KEY = 'token';
+    vi.spyOn(window, 'alert').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -45,6 +46,8 @@ describe('PostGenerator', () => {
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
 
     fireEvent.click(screen.getByText(/publish now/i));
-    await waitFor(() => expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'));
+    await waitFor(() =>
+      expect(publishPosts).toHaveBeenCalledWith('Generated', ['LinkedIn'], { LinkedIn: 'token' }),
+    );
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -164,6 +164,27 @@ export async function publishPost(
 }
 
 /**
+ * Publishes a post to multiple platforms.
+ *
+ * @param text - Content to publish.
+ * @param platforms - List of target platforms.
+ * @param tokenMap - Mapping of platform names to access tokens.
+ */
+export async function publishPosts(
+  text: string,
+  platforms: string[],
+  tokenMap: Record<string, string>,
+) {
+  for (const platform of platforms) {
+    const token = tokenMap[platform];
+    if (!token) {
+      throw new ApiException(`${platform} API key not configured`);
+    }
+    await publishPost(text, platform, token);
+  }
+}
+
+/**
  * Sends a direct message to a LinkedIn user.
  *
  * @param text - Message body to deliver.


### PR DESCRIPTION
## Summary
- Replace single platform dropdown with multi-select checkboxes
- Add API helper to publish posts across multiple platforms
- Adjust tests for new publishPosts flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895d8a45434833291302c296e7f1e8b