### PR TITLE
Require platform selection before generating posts

### DIFF
--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -27,6 +27,9 @@ describe('PostGenerator', () => {
 
   it('calls generateContent when generate button is clicked', async () => {
     render(<PostGenerator />);
+    fireEvent.change(screen.getByLabelText(/Platform/i), {
+      target: { value: 'LinkedIn' },
+    });
     fireEvent.change(
       screen.getByPlaceholderText(/Enter a topic or detailed instructions for GPT.../i),
       { target: { value: 'Topic' } },
@@ -37,6 +40,9 @@ describe('PostGenerator', () => {
 
   it('publishes generated content when publish button is clicked', async () => {
     render(<PostGenerator />);
+    fireEvent.change(screen.getByLabelText(/Platform/i), {
+      target: { value: 'LinkedIn' },
+    });
     fireEvent.change(
       screen.getByPlaceholderText(/Enter a topic or detailed instructions for GPT.../i),
       { target: { value: 'Topic' } },
@@ -45,6 +51,8 @@ describe('PostGenerator', () => {
     await waitFor(() => expect(generateContent).toHaveBeenCalled());
 
     fireEvent.click(screen.getByText(/publish now/i));
-    await waitFor(() => expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'));
+    await waitFor(() =>
+      expect(publishPost).toHaveBeenCalledWith('Generated', 'LinkedIn', 'token'),
+    );
   });
 });

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -34,7 +34,7 @@ const PostGenerator: React.FC = () => {
   const [imageUrl, setImageUrl] = useState('');
   const [selectedImages, setSelectedImages] = useState<ImagePreview[]>([]);
   const [dragActive, setDragActive] = useState(false);
-  const [platform, setPlatform] = useState('LinkedIn');
+  const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>([]);
   const [tone, setTone] = useState('Professional');
   const [hashtags, setHashtags] = useState('');
   const { user } = useAuthStore();
@@ -108,6 +108,12 @@ const PostGenerator: React.FC = () => {
   };
 
   const handleGenerate = async () => {
+    if (selectedPlatforms.length === 0) {
+      alert('Please select at least one platform');
+      return;
+    }
+
+    const platform = selectedPlatforms[0];
     setIsGenerating(true);
     try {
       const tags = formatHashtags(hashtags);
@@ -129,6 +135,12 @@ const PostGenerator: React.FC = () => {
   };
 
   const handlePublish = async () => {
+    if (selectedPlatforms.length === 0) {
+      alert('Please select a platform');
+      return;
+    }
+
+    const platform = selectedPlatforms[0];
     const tags = formatHashtags(hashtags);
     const contentToShare = tags ? `${generatedContent}\n\n${tags}` : generatedContent;
 
@@ -173,14 +185,21 @@ const PostGenerator: React.FC = () => {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
         <div className="md:col-span-2">
           <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="platform"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Platform
             </label>
             <select
-              value={platform}
-              onChange={(e) => setPlatform(e.target.value)}
+              id="platform"
+              value={selectedPlatforms[0] || ''}
+              onChange={(e) =>
+                setSelectedPlatforms(e.target.value ? [e.target.value] : [])
+              }
               className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-[#0A66C2] focus:ring-[#0A66C2]"
             >
+              <option value="">Select a platform</option>
               <option value="LinkedIn">LinkedIn</option>
               <option value="Twitter">Twitter</option>
               <option value="Facebook">Facebook</option>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,3 +1,8 @@
 import '@testing-library/jest-dom/vitest';
+import { vi } from 'vitest';
+
 process.env.VITE_SUPABASE_URL = 'http://localhost';
 process.env.VITE_SUPABASE_ANON_KEY = 'test';
+
+// Stub alert for tests running in jsdom environment
+globalThis.alert = vi.fn();


### PR DESCRIPTION
## Summary
- Require a platform selection before generating content and use the first selected platform
- Warn when publishing without a selected platform and update platform dropdown to allow empty state
- Stub `window.alert` in tests and update post generator tests accordingly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895db8f8bc4833292d7044710d4d724