### PR TITLE
feat: add translation and rewrite features

### DIFF
--- a/src/__tests__/PostGenerator.test.tsx
+++ b/src/__tests__/PostGenerator.test.tsx
@@ -10,6 +10,8 @@ vi.mock('../lib/api', async () => {
     generateContent: vi.fn(),
     publishPost: vi.fn(),
     sendLinkedInMessage: vi.fn(),
+    translateContent: vi.fn(),
+    rewriteContent: vi.fn(),
   };
 });
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,6 +55,78 @@ export async function generateContent(prompt: string, platform: string): Promise
 }
 
 /**
+ * Translates text into the target language using the OpenAI Chat Completion API.
+ *
+ * @param text - The source text to translate.
+ * @param targetLang - Language to translate the text into.
+ * @returns The translated text.
+ * @throws ApiException When the API key is missing or the request fails.
+ */
+export async function translateContent(text: string, targetLang: string): Promise<string> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  if (!apiKey) throw new ApiException('OpenAI API key not configured');
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: `You are a translation assistant that translates text to ${targetLang}.` },
+          { role: 'user', content: text },
+        ],
+      }),
+    });
+    if (!response.ok) throw new ApiException('Failed to translate content', response.status);
+    const data = await response.json();
+    return data.choices[0].message.content.trim();
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while translating content');
+  }
+}
+
+/**
+ * Rewrites text in a specified tone using the OpenAI Chat Completion API.
+ *
+ * @param text - The original text to rewrite.
+ * @param tone - Desired tone for the rewritten text.
+ * @returns The rewritten text.
+ * @throws ApiException When the API key is missing or the request fails.
+ */
+export async function rewriteContent(text: string, tone: string): Promise<string> {
+  const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+  if (!apiKey) throw new ApiException('OpenAI API key not configured');
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          { role: 'system', content: `You rewrite the user's text in a ${tone} tone.` },
+          { role: 'user', content: text },
+        ],
+      }),
+    });
+    if (!response.ok) throw new ApiException('Failed to rewrite content', response.status);
+    const data = await response.json();
+    return data.choices[0].message.content.trim();
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while rewriting content');
+  }
+}
+
+/**
  * Publishes a post to LinkedIn using the REST API.
  *
  * @param text - The body of the LinkedIn post.


### PR DESCRIPTION
## Summary
- add translateContent and rewriteContent helpers using OpenAI chat completions
- allow posts to be translated or rewritten through a modal with throttling and error handling
- update tests to mock new API helpers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899b34cebc48332b02fc556c64e97bd