### PR TITLE
feat: shorten links and show previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@ VITE_SUPABASE_ANON_KEY=your_supabase_anon_key_here
 # API Keys (Optional - Configure in Settings)
 # VITE_OPENAI_API_KEY=your_openai_api_key_here
 # VITE_LINKEDIN_API_KEY=your_linkedin_api_key_here
+# VITE_TINYURL_API_KEY=your_tinyurl_api_key_here
 
 # Calendar Integration (Optional)
 # VITE_GOOGLE_CLIENT_ID=your_google_client_id_here

--- a/src/components/common/LinkPreview.tsx
+++ b/src/components/common/LinkPreview.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+interface LinkPreviewProps {
+  url: string;
+  title: string;
+  description: string;
+}
+
+/**
+ * Displays a preview for a link including its title and description.
+ */
+const LinkPreview: React.FC<LinkPreviewProps> = ({ url, title, description }) => {
+  return (
+    <div className="mt-2 p-4 border rounded-md bg-gray-50">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-[#0A66C2] font-medium hover:underline"
+      >
+        {title}
+      </a>
+      {description && (
+        <p className="text-sm text-gray-600 mt-1">{description}</p>
+      )}
+    </div>
+  );
+};
+
+export default LinkPreview;


### PR DESCRIPTION
## Summary
- integrate TinyURL-based `shortenLink` and metadata `fetchLinkPreview` helpers
- display link previews in `PostGenerator` and shorten URLs before publishing
- document TinyURL API key in example env file

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899b34d2fe88332a6f4a409df669872