### PR TITLE
Add analytics dashboard and post metrics tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "recharts": "^2.9.0",
     "react-i18next": "^14.0.5",
     "react-router-dom": "^6.23.0",
     "zustand": "^4.5.1"

--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState } from 'react';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts';
+import Card from '../common/Card';
+import { fetchPostMetrics } from '../../lib/api';
+import type { PostMetrics } from '../../types';
+
+interface AnalyticsDashboardProps {
+  postIds: string[];
+}
+
+const AnalyticsDashboard: React.FC<AnalyticsDashboardProps> = ({ postIds }) => {
+  const [metrics, setMetrics] = useState<PostMetrics[]>([]);
+
+  useEffect(() => {
+    if (postIds.length === 0) return;
+    fetchPostMetrics(postIds).then(setMetrics).catch(console.error);
+  }, [postIds]);
+
+  const platforms = Array.from(new Set(metrics.map((m) => m.platform)));
+
+  const chartData = postIds.map((id) => {
+    const entry: Record<string, string | number> = { post: id };
+    metrics
+      .filter((m) => m.postId === id)
+      .forEach((m) => {
+        entry[m.platform] = m.views;
+      });
+    return entry;
+  });
+
+  const colors: Record<string, string> = {
+    LinkedIn: '#0e76a8',
+    Twitter: '#1DA1F2',
+    Facebook: '#1877F2',
+  };
+
+  return (
+    <Card title="Post Performance">
+      <div className="w-full h-80">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="post" />
+            <YAxis />
+            <Tooltip />
+            <Legend />
+            {platforms.map((p) => (
+              <Bar key={p} dataKey={p} fill={colors[p] || '#8884d8'} />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </Card>
+  );
+};
+
+export default AnalyticsDashboard;

--- a/src/components/posts/PostGenerator.tsx
+++ b/src/components/posts/PostGenerator.tsx
@@ -143,9 +143,9 @@ const PostGenerator: React.FC = () => {
     const platform = selectedPlatforms[0];
     const tags = formatHashtags(hashtags);
     const contentToShare = tags ? `${generatedContent}\n\n${tags}` : generatedContent;
-    const selectedPlatforms = platform ? [platform] : [];
+    const platformsToPublish = platform ? [platform] : [];
 
-    if (selectedPlatforms.length === 0) {
+    if (platformsToPublish.length === 0) {
       alert('Please select at least one platform to publish.');
       return;
     }
@@ -153,7 +153,7 @@ const PostGenerator: React.FC = () => {
     if (scheduledDate && scheduledTime) {
       try {
         const scheduledAt = new Date(`${scheduledDate}T${scheduledTime}:00`).toISOString();
-        await schedulePost(user?.id || '', contentToShare, selectedPlatforms, scheduledAt);
+        await schedulePost(user?.id || '', contentToShare, platformsToPublish, scheduledAt);
         alert('Post scheduled successfully!');
       } catch (err) {
         console.error(err);
@@ -167,7 +167,7 @@ const PostGenerator: React.FC = () => {
     }
 
     const env = import.meta.env as Record<string, string | undefined>;
-    const tokenMap = selectedPlatforms.reduce<Record<string, string>>((acc, p) => {
+    const tokenMap = platformsToPublish.reduce<Record<string, string>>((acc, p) => {
       const token = env[`VITE_${p.toUpperCase()}_API_KEY`];
       if (token) {
         acc[p] = token;
@@ -175,7 +175,7 @@ const PostGenerator: React.FC = () => {
       return acc;
     }, {});
 
-    for (const p of selectedPlatforms) {
+    for (const p of platformsToPublish) {
       if (!tokenMap[p]) {
         alert(`${p} API key not configured`);
         return;
@@ -183,7 +183,7 @@ const PostGenerator: React.FC = () => {
     }
 
     try {
-      for (const p of selectedPlatforms) {
+      for (const p of platformsToPublish) {
         await publishPost(contentToShare, p, tokenMap[p]);
       }
       alert('Post published successfully!');

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import type { PostMetrics } from '../types';
+
 export class ApiException extends Error {
   status?: number;
   code?: string;
@@ -61,7 +63,7 @@ export async function generateContent(prompt: string, platform: string): Promise
  * @param accessToken - OAuth token granting publish permissions.
  * @throws ApiException When the request fails or a network error occurs.
  */
-export async function sendLinkedInPost(text: string, accessToken: string) {
+export async function sendLinkedInPost(text: string, accessToken: string): Promise<string> {
   try {
     const response = await fetch('https://api.linkedin.com/v2/ugcPosts', {
       method: 'POST',
@@ -83,6 +85,8 @@ export async function sendLinkedInPost(text: string, accessToken: string) {
       }),
     });
     if (!response.ok) throw new ApiException('Failed to publish post', response.status);
+    const data = await response.json();
+    return data.id as string;
   } catch (err) {
     if (err instanceof ApiException) throw err;
     throw new ApiException('Network error while publishing post');
@@ -96,7 +100,7 @@ export async function sendLinkedInPost(text: string, accessToken: string) {
  * @param accessToken - OAuth token granting publish permissions.
  * @throws ApiException When the request fails or a network error occurs.
  */
-export async function sendTwitterPost(text: string, accessToken: string) {
+export async function sendTwitterPost(text: string, accessToken: string): Promise<string> {
   try {
     const response = await fetch('https://api.twitter.com/2/tweets', {
       method: 'POST',
@@ -107,6 +111,8 @@ export async function sendTwitterPost(text: string, accessToken: string) {
       body: JSON.stringify({ text }),
     });
     if (!response.ok) throw new ApiException('Failed to publish post', response.status);
+    const data = await response.json();
+    return data.data?.id as string;
   } catch (err) {
     if (err instanceof ApiException) throw err;
     throw new ApiException('Network error while publishing post');
@@ -120,7 +126,7 @@ export async function sendTwitterPost(text: string, accessToken: string) {
  * @param accessToken - OAuth token granting publish permissions.
  * @throws ApiException When the request fails or a network error occurs.
  */
-export async function sendFacebookPost(text: string, accessToken: string) {
+export async function sendFacebookPost(text: string, accessToken: string): Promise<string> {
   try {
     const response = await fetch(
       `https://graph.facebook.com/v18.0/me/feed?access_token=${accessToken}`,
@@ -133,6 +139,8 @@ export async function sendFacebookPost(text: string, accessToken: string) {
       },
     );
     if (!response.ok) throw new ApiException('Failed to publish post', response.status);
+    const data = await response.json();
+    return data.id as string;
   } catch (err) {
     if (err instanceof ApiException) throw err;
     throw new ApiException('Network error while publishing post');
@@ -151,15 +159,47 @@ export async function publishPost(
   platform: string,
   accessToken: string,
 ) {
+  let postId: string;
   switch (platform) {
     case 'LinkedIn':
-      return sendLinkedInPost(text, accessToken);
+      postId = await sendLinkedInPost(text, accessToken);
+      break;
     case 'Twitter':
-      return sendTwitterPost(text, accessToken);
+      postId = await sendTwitterPost(text, accessToken);
+      break;
     case 'Facebook':
-      return sendFacebookPost(text, accessToken);
+      postId = await sendFacebookPost(text, accessToken);
+      break;
     default:
       throw new ApiException('Unsupported platform');
+  }
+  await savePostReference(postId, platform);
+  return postId;
+}
+
+async function savePostReference(postId: string, platform: string) {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) return;
+  try {
+    await fetch(`${supabaseUrl}/rest/v1/post_metrics`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseAnonKey,
+        Authorization: `Bearer ${supabaseAnonKey}`,
+      },
+      body: JSON.stringify({
+        post_id: postId,
+        platform,
+        views: 0,
+        likes: 0,
+        comments: 0,
+        shares: 0,
+      }),
+    });
+  } catch {
+    // Ignore errors saving references
   }
 }
 
@@ -201,10 +241,42 @@ export async function schedulePost(
       }),
     });
     if (!response.ok) throw new ApiException('Failed to schedule post', response.status);
-    return response.json();
+    const data = await response.json();
+    for (const platform of platforms) {
+      await savePostReference(data.id, platform);
+    }
+    return data;
   } catch (err) {
     if (err instanceof ApiException) throw err;
     throw new ApiException('Network error while scheduling post');
+  }
+}
+
+export async function fetchPostMetrics(postIds: string[]): Promise<PostMetrics[]> {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new ApiException('Supabase not configured');
+  }
+
+  try {
+    const filter = postIds.map((id) => `"${id}"`).join(',');
+    const response = await fetch(
+      `${supabaseUrl}/rest/v1/post_metrics?post_id=in.(${filter})`,
+      {
+        headers: {
+          apikey: supabaseAnonKey,
+          Authorization: `Bearer ${supabaseAnonKey}`,
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new ApiException('Failed to fetch post metrics', response.status);
+    }
+    return response.json();
+  } catch (err) {
+    if (err instanceof ApiException) throw err;
+    throw new ApiException('Network error while fetching post metrics');
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -52,3 +52,12 @@ export interface ApiError {
   code?: string;
   status?: number;
 }
+
+export interface PostMetrics {
+  postId: string;
+  platform: string;
+  views: number;
+  likes: number;
+  comments: number;
+  shares: number;
+}


### PR DESCRIPTION
## Summary
- add Recharts dependency and new analytics dashboard component for cross-platform post performance
- track published/scheduled post IDs in Supabase and expose fetchPostMetrics API
- fix platform selection in post generator to avoid runtime errors when publishing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b350f1588332a0cc597c86af4efa