### PR TITLE
feat: add env type declarations

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,17 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL: string
+  readonly VITE_SUPABASE_ANON_KEY: string
+  readonly VITE_OPENAI_API_KEY: string
+  readonly VITE_LINKEDIN_API_KEY: string
+  readonly VITE_GOOGLE_CLIENT_ID: string
+  readonly VITE_GOOGLE_CLIENT_SECRET: string
+  readonly VITE_OUTLOOK_CLIENT_ID: string
+  readonly VITE_OUTLOOK_CLIENT_SECRET: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}
+


### PR DESCRIPTION
## Summary
- declare typed ImportMetaEnv variables for Supabase, OpenAI, LinkedIn, Google, and Outlook
- expose env on ImportMeta for better autocompletion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b529f52888332861a1b9a3907ade9